### PR TITLE
Add space between footer and body of contact page

### DIFF
--- a/app/Contact/page.jsx
+++ b/app/Contact/page.jsx
@@ -111,7 +111,7 @@ const ContactForm = () => {
 const Contact = () => {
   return (
     <>
-      <div className="flex flex-col items-center w-full px-4 mt-8">
+      <div className="flex flex-col items-center w-full px-4 mt-8 mb-4">
         <Toaster />
         <div className="flex flex-wrap justify-center gap-8 sm:w-3/4 p-3 bg-white shadow-lg mt-3">
           <ContactForm />


### PR DESCRIPTION
**Type:** Enhancement

**Description:**
 - Added margin bottom to the contact component in the contact page. 
 
**Related Issue:**
   #6 

**Screenshots**
- **Before**
<img width="700" height="500" alt="Screenshot 2025-07-22 180658" src="https://github.com/user-attachments/assets/e9b53fd6-45c0-4aec-9496-9c3d209e2b9a" />

- **After**      
<img width="700" height="500" alt="Screenshot 2025-07-23 103243" src="https://github.com/user-attachments/assets/10052357-dfcf-45af-95ae-55295c9972b6" />

