### PR TITLE
style(otp): center align input and increase box size

### DIFF
--- a/app/user/User_Profile/_Userinfo/Userinfo.jsx
+++ b/app/user/User_Profile/_Userinfo/Userinfo.jsx
@@ -455,13 +455,13 @@ const Userinfo = () => {
                 value={otp}
                 onChange={(value) => setOtp(value)}
               >
-                <InputOTPGroup>
-                  <InputOTPSlot index={0} />
-                  <InputOTPSlot index={1} />
-                  <InputOTPSlot index={2} />
-                  <InputOTPSlot index={3} />
-                  <InputOTPSlot index={4} />
-                  <InputOTPSlot index={5} />
+                <InputOTPGroup className="w-full justify-center gap-2">
+                  <InputOTPSlot index={0} className="w-12"/>
+                  <InputOTPSlot index={1} className="w-12"/>
+                  <InputOTPSlot index={2} className="w-12"/>
+                  <InputOTPSlot index={3} className="w-12"/>
+                  <InputOTPSlot index={4} className="w-12"/>
+                  <InputOTPSlot index={5} className="w-12"/>
                 </InputOTPGroup>
               </InputOTP>
             </div>


### PR DESCRIPTION
- Applied `justify-center` to align the OTP input group to the center
- Increased slot width from `w-9` to `w-12` to allow characters to fit properly
- Improves overall readability and UX for OTP input
