### PR TITLE
Revert "Fix Navbar z index and also remove the Duplicate Marquee Element"

### DIFF
--- a/app/_components/MarqeeImage.jsx
+++ b/app/_components/MarqeeImage.jsx
@@ -160,7 +160,43 @@ function MarqueeImages() {
         </div>
       </div>
       
-      {/* Deleted the bottom maquee as requested */}
+      {/* Bottom Marquee */}
+      <div
+        className="relative"
+        onMouseEnter={() => setBottomHover(true)}
+        onMouseLeave={() => setBottomHover(false)}
+      >
+        <div className="absolute left-0 top-0 h-full w-20 bg-gradient-to-r from-black to-transparent pointer-events-none z-10" />
+        <div className="absolute right-0 top-0 h-full w-20 bg-gradient-to-l from-black to-transparent pointer-events-none z-10" />
+        <div className="flex">
+          <div
+            ref={bottomRef}
+            className="flex gap-6"
+            style={{
+              width: "300%",
+              willChange: "transform",
+            }}
+          >
+            {tripleImages.map((img, idx) => (
+              <div
+                key={idx}
+                className="flex-shrink-0 w-64 h-52 sm:w-72 sm:h-56 md:w-80 md:h-60 lg:w-88 lg:h-64 rounded-xl overflow-hidden shadow-xl border border-gray-700"
+              >
+                <Image
+                  src={img.src}
+                  alt={img.alt}
+                  className="w-full h-full object-cover transition-all duration-300 hover:brightness-110"
+                  draggable={false}
+                  width={352}
+                  height={224}
+                  loading="lazy"
+                  quality={85}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
       
       <style jsx>{`
         .w-88 {

--- a/app/_components/Navbar.jsx
+++ b/app/_components/Navbar.jsx
@@ -103,7 +103,7 @@ const Navbar = () => {
 
   const pathname = usePathname();
   return (
-    <div className="bg-black flex justify-center text-white sticky top-0 !z-[99] !font-serif">
+    <div className="bg-black flex justify-center text-white sticky top-0 z-[10] !font-serif">
       {/* navbar big screen  */}
       <div className="w-full xl:w-[95%] justify-between sm:flex hidden">
       <Link href="/">


### PR DESCRIPTION
Reverts AyushSharma72/Skill_Trade#76

Please revert the recent merge that removed the Bottom Marquee element from the UI. The Bottom Marquee is not a duplicate; it is an intentional design choice commonly used on many modern websites. Having both top and bottom marquees, moving in opposite directions, creates an engaging and visually appealing effect for users. Removing it negatively impacts the intended user experience and the overall look of the page.

Kindly restore the Bottom Marquee as it is an important part of our UI style.

Thank you!

https://github.com/user-attachments/assets/dcf9f134-93fa-47a1-a166-dfb2d6703c61
